### PR TITLE
Remove broken and unrequired dependencies.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,10 +52,7 @@ class matlab::vardir {	# module vardir snippet
 }
 
 class matlab() {
-	# dependencies for matlab to work
-	package {['libXp', 'libXt', 'libXpm', 'libXmu']:
-		ensure => present,
-	}
+
 }
 
 define matlab::install(			# $namevar matlab release version


### PR DESCRIPTION
Matlab does not need the packages listed as dependencies to
work. Moreover, they are not available in Ubuntu 16.04.
